### PR TITLE
fix: Remove Navigation bar of creator app in /channels page as it is overlaying on the NavBar Fixes #21

### DIFF
--- a/apps/creator/app/channels/components/Header.tsx
+++ b/apps/creator/app/channels/components/Header.tsx
@@ -7,7 +7,12 @@ import { Menu } from 'lucide-react';
 export const ChannelHeader = () => {
   const { setOpen, open } = useSidebar();
   return (
-    <div className="fixed top-0 left-0 md:left-[var(--sidebar-width)] md:right-[var(--sidebar-width)] right-0 flex flex-row bg-white dark:bg-black items-center justify-between border-b bg-gradient-to-bl px-2 z-40 h-16">
+    <div
+      className={`fixed top-0 left-0 md:left-(--sidebar-width)
+        md:right-(--sidebar-width) right-0 flex flex-row bg-white
+     dark:bg-black items-center justify-between border-b
+      bg-linear-to-bl px-2 z-40 h-16`}
+    >
       <div className="flex flex-row items-center gap-2">
         {!open && (
           <Button onClick={() => setOpen(true)}>

--- a/apps/creator/components/AppHeader.tsx
+++ b/apps/creator/components/AppHeader.tsx
@@ -3,12 +3,14 @@
 import { Icons } from '@/lib/icons/Icons';
 import { ReturnToPreviousPage } from '@workspace/ui/globals/ReturnToPreviousPage';
 import { ApplyHeaderOptions } from './ApplyHeaderOptions';
+import { usePathname } from 'next/navigation';
 
 interface Props {
   header?: string;
 }
 export const AppHeader: React.FC<Props> = ({ header }) => {
-  return (
+  const pathname = usePathname();
+  return !pathname.startsWith('/channels') ? (
     <header
       className={`sticky top-0 z-50 border-b
         bg-linear-to-bl from-background
@@ -26,5 +28,5 @@ export const AppHeader: React.FC<Props> = ({ header }) => {
         </div>
       </div>
     </header>
-  );
+  ) : null;
 };


### PR DESCRIPTION
Fixes #21
Solved this problem using next usePathname() hook with a ternary operator to get disable the Root layout header on the /channels path 